### PR TITLE
No success messages if the initial PR check is valid

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
         SUCCESS_MESSAGE: ${{ inputs.success-message }}
 
     - name: Create comment
-      if: ${{ steps.fc.outputs.comment-id || steps.check.outputs.exit_code != "0" }}
+      if: ${{ steps.fc.outputs.comment-id || steps.check.outputs.exit_code != '0' }}
       uses: peter-evans/create-or-update-comment@v5
       with:
         issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This PR closes #6 

### Type of Change
- [X] Bug fix 🐛

### Checklist
- [X] I’ve read the contributing guidelines  
- [X] I've already assigned this PR to an issue before submitting  
- [X] My code follows the project’s style and conventions  
- [X] I have tested the functionality and performed a self-review  
- [X] I have run all quality checks before submitting this PR:
- [X] I've added closing terms (eg: closes, resolves, fixes)

### Description
This PR will disable reporting success messages if for a fresh PR.

## Summary by Sourcery

Bug Fixes:
- Suppress success messages for fresh PRs that have no existing comment and a passing check